### PR TITLE
docs: fix all stale content across landing pages

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -33,14 +33,14 @@ const { title, description = "Real-time DeFi yield intelligence with multi-facto
         { "@type": "Offer", "price": "0", "priceCurrency": "USD", "name": "Free" },
         { "@type": "Offer", "price": "9.99", "priceCurrency": "USD", "name": "Pro" }
       ],
-      "description": "DeFi yield intelligence bot — monitors 3,800+ pools across 6 chains, scores risk 0-100, pushes alerts to Telegram"
+      "description": "DeFi yield intelligence bot — monitors 3,800+ pools across 10 chains, scores risk 0-100 with 10 weighted factors, pushes alerts to Telegram"
     })} />
     <script type="application/ld+json" set:html={JSON.stringify({
       "@context": "https://schema.org",
       "@type": "WebSite",
       "name": "YieldRadar",
       "url": "https://yieldradar.io",
-      "description": "DeFi yield intelligence — monitors 3,800+ pools across 6 chains with multi-factor risk scoring"
+      "description": "DeFi yield intelligence — monitors 3,800+ pools across 10 chains with 10-factor risk scoring"
     })} />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -20,15 +20,21 @@ import BaseLayout from '../layouts/BaseLayout.astro'
     <div class="changelog-body">
       <h3>Features</h3>
       <ul>
+        <li>4 new chains — Optimism, Avalanche, Hyperliquid L1, Sui (total: 10 chains, covering 85%+ DeFi TVL)</li>
         <li>Alert deduplication with persistent tracking — no more duplicate notifications for the same pool within a scan cycle</li>
         <li>Minimum APY filter — set a floor to only receive alerts above your target yield</li>
         <li>Data export — export your alert history and pool data for personal analysis</li>
+        <li>GoPlus expanded to 5 security endpoints — token, address, rugpull, approval, and phishing site detection</li>
+        <li>Emission decay detection — flags pools with unsustainable reward structures</li>
+        <li>Simplified onboarding — reduced from 5 steps to 3 for faster setup</li>
       </ul>
       <h3>Improvements</h3>
       <ul>
         <li>GoPlus authentication flow rewritten for reliability — fewer failed security checks during high-load periods</li>
-        <li>API audit fixes across the data pipeline — improved error handling and retry logic for DeFiLlama fetches</li>
+        <li>Pipeline fetch hang fix — resolved timeout issues in DeFiLlama data pulls</li>
+        <li>API audit fixes across the data pipeline — improved error handling and retry logic</li>
         <li>Alert message formatting improvements with inline action buttons</li>
+        <li>Test suite expanded from 504 to 740 tests</li>
       </ul>
     </div>
   </div>
@@ -65,8 +71,8 @@ import BaseLayout from '../layouts/BaseLayout.astro'
     <div class="changelog-body">
       <h3>Features</h3>
       <ul>
-        <li>Data pipeline with 5-minute polling from DeFiLlama across 6 chains (Ethereum, Base, Solana, Arbitrum, BSC, Polygon)</li>
-        <li>Multi-factor risk scoring engine with 6 weighted factors per pool</li>
+        <li>Data pipeline with 5-minute polling from DeFiLlama (started with 6 chains, now 10)</li>
+        <li>Multi-factor risk scoring engine with 10 weighted factors per pool</li>
         <li>Telegram bot with onboarding flow, real-time alerts, daily digest, deep-dive analysis, and settings</li>
         <li>User management with freemium tiers (Free: 10 alerts/day, Pro: unlimited)</li>
         <li>Docker deployment with multi-stage build and health monitoring</li>
@@ -76,7 +82,7 @@ import BaseLayout from '../layouts/BaseLayout.astro'
         <li>SQLite (better-sqlite3, WAL mode) for persistent storage</li>
         <li>Grammy bot framework with conversations plugin</li>
         <li>Node.js 24 with TypeScript (ESM, strict mode)</li>
-        <li>Vitest test suite (504 tests)</li>
+        <li>Vitest test suite (740 tests)</li>
       </ul>
     </div>
   </div>

--- a/src/pages/docs.astro
+++ b/src/pages/docs.astro
@@ -29,7 +29,7 @@ import BaseLayout from '../layouts/BaseLayout.astro'
     <dt>Database</dt>
     <dd>SQLite (better-sqlite3, WAL mode)</dd>
     <dt>Testing</dt>
-    <dd>Vitest (504 tests)</dd>
+    <dd>Vitest (740 tests)</dd>
     <dt>Deployment</dt>
     <dd>Docker, multi-stage build</dd>
   </dl>
@@ -67,7 +67,7 @@ import BaseLayout from '../layouts/BaseLayout.astro'
         <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6m8 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0h6m0 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14"/></svg>
       </div>
       <h3>Score</h3>
-      <p>6-factor risk model (0–100)</p>
+      <p>10-factor risk model (0–100)</p>
     </div>
     <div class="pipeline-arrow">→</div>
     <div class="pipeline-step">
@@ -78,7 +78,7 @@ import BaseLayout from '../layouts/BaseLayout.astro'
       <p>Matched to user preferences → Telegram</p>
     </div>
   </div>
-  <p class="docs-note">Data flows in one direction. The bot polls DeFiLlama every 5 minutes, filters down to ~3,800 eligible pools, scores each one on six risk factors, and pushes matches to subscribed users.</p>
+  <p class="docs-note">Data flows in one direction. The bot polls DeFiLlama every 5 minutes, filters down to ~3,800 eligible pools, scores each one on ten risk factors, and pushes matches to subscribed users.</p>
 </section>
 
 <section class="section-inner docs-section">
@@ -117,7 +117,7 @@ import BaseLayout from '../layouts/BaseLayout.astro'
       <span class="docs-step-num">4</span>
       <div>
         <h3>Scoring</h3>
-        <p>Each eligible pool receives a <strong>6-factor composite score</strong> (0–100). See the risk scoring model below for the formula.</p>
+        <p>Each eligible pool receives a <strong>10-factor composite score</strong> (0–100). See the risk scoring model below for the formula.</p>
       </div>
     </div>
     <div class="docs-step">
@@ -132,17 +132,20 @@ import BaseLayout from '../layouts/BaseLayout.astro'
 
 <section class="section-inner docs-section">
   <h2>Risk scoring model</h2>
-  <p>Each pool receives a composite score based on six weighted factors. The score is normalized to a 0–100 scale where higher is safer.</p>
+  <p>Each pool receives a composite score based on ten weighted factors. The score is normalized to a 0–100 scale where higher is safer.</p>
 
   <h3>The formula</h3>
   <div class="docs-formula">
     <p><code>rawScore = APY / max(sigma, 0.01)</code></p>
     <p class="formula-note">where <strong>sigma</strong> is the standard deviation of APY over available snapshots — measures yield stability</p>
 
-    <p><code>riskAdjustedScore = rawScore × TVL_multiplier × trend_multiplier × IL_multiplier × maturity_multiplier × security_multiplier</code></p>
-    <p class="formula-note">each multiplier adjusts the raw score up or down based on pool-specific risk factors</p>
+    <p><code>riskAdjustedScore = rawScore × TVL_multiplier × trend_multiplier × IL_multiplier × maturity_multiplier</code></p>
+    <p class="formula-note">four core multipliers adjust the raw score up or down based on pool-specific risk factors</p>
 
-    <p><code>normalizedScore = scale(riskAdjustedScore, 0, 100)</code></p>
+    <p><code>finalScore = riskAdjustedScore × securityMultiplier × protocolTierMultiplier × addressSecurityMultiplier × rugpullMultiplier × protocolRiskMultiplier × emissionMultiplier</code></p>
+    <p class="formula-note">six additional GoPlus, protocol, and emission factors — each as a weighted multiplier (0.0–1.0)</p>
+
+    <p><code>normalizedScore = scale(finalScore, 0, 100)</code></p>
     <p class="formula-note">linear scaling to the 0–100 range for consistent tier classification</p>
   </div>
 
@@ -216,13 +219,31 @@ import BaseLayout from '../layouts/BaseLayout.astro'
           <td>Token security</td>
           <td>0.0–1.0 multiplier</td>
           <td>GoPlus API</td>
-          <td>Honeypot detection, malicious contract scan, token tax analysis</td>
+          <td>Honeypot detection, malicious contract scan, token tax analysis (15 conditions)</td>
         </tr>
         <tr>
-          <td>Protocol metadata</td>
+          <td>Address security</td>
+          <td>0.0–1.0 multiplier</td>
+          <td>GoPlus API</td>
+          <td>Malicious address flags — sanctions, phishing, blacklist, honeypot creator</td>
+        </tr>
+        <tr>
+          <td>Rugpull detection</td>
+          <td>0.0–1.0 multiplier</td>
+          <td>GoPlus API</td>
+          <td>Rugpull risk scoring based on contract patterns and holder distribution</td>
+        </tr>
+        <tr>
+          <td>Protocol tier</td>
           <td>Tier classification</td>
           <td>DeFiLlama protocols</td>
-          <td>Audit status, protocol age, and category factor into risk</td>
+          <td>Audit status, protocol age, and category factor into risk via tier multiplier</td>
+        </tr>
+        <tr>
+          <td>Emission decay</td>
+          <td>0.0–1.0 multiplier</td>
+          <td>Internal (APY history)</td>
+          <td>Detects emission-based yields and penalizes decaying reward structures</td>
         </tr>
       </tbody>
     </table>
@@ -259,7 +280,7 @@ import BaseLayout from '../layouts/BaseLayout.astro'
     <dt>DeFiLlama</dt>
     <dd>Primary data source — pool data, APY, TVL, 7d APY change, protocol metadata, audit status, and chain information. Polled every 5 minutes.</dd>
     <dt>GoPlus Security</dt>
-    <dd>Token-level security analysis — honeypot detection, malicious contract scanning, transfer tax analysis, and token safety scoring. Integrated as a weighted factor in the composite risk score, not just a pass/fail check.</dd>
+    <dd>Multi-endpoint security analysis — token security (honeypot, malicious contracts, transfer tax), address security (sanctions, phishing), rugpull detection, approval security, and phishing site detection. Each endpoint contributes a weighted multiplier to the composite risk score.</dd>
   </dl>
 </section>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -28,7 +28,7 @@ import BaseLayout from '../layouts/BaseLayout.astro'
       "name": "What chains are supported?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "We currently monitor pools on Ethereum, Base, Solana, Arbitrum, BSC, and Polygon — covering over 75% of all DeFi TVL. More chains are planned for future updates."
+        "text": "We currently monitor pools on 10 chains — Ethereum, Base, Solana, Arbitrum, BSC, Polygon, Optimism, Avalanche, Hyperliquid L1, and Sui — covering over 85% of all DeFi TVL."
       }
     },
     {
@@ -36,7 +36,7 @@ import BaseLayout from '../layouts/BaseLayout.astro'
       "name": "How does the risk scoring work?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Every pool is scored 0–100 based on six factors: APY volatility, TVL quality, 7-day trend, impermanent loss risk, pool maturity, and GoPlus token security analysis. Each factor has a specific weight in the composite score."
+        "text": "Every pool is scored 0–100 based on ten weighted factors: APY volatility, TVL quality, 7-day trend, impermanent loss risk, pool maturity, GoPlus token security, address security, rugpull detection, protocol tier, and emission decay. Each factor has a specific weight in the composite score."
       }
     },
     {
@@ -84,7 +84,7 @@ import BaseLayout from '../layouts/BaseLayout.astro'
       "name": "What are the alert buttons?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Every alert has three inline buttons: Details (opens a deep-dive analysis with yield breakdown, risk factors, and similar pools), Invest (links directly to the pool on DeFiLlama), and Mute (silences alerts for that pool)."
+        "text": "Every alert has three inline buttons: Details (opens a deep-dive analysis with yield breakdown, risk factors, and similar pools), Invest (links to the protocol page on DeFiLlama), and Mute (silences alerts for that pool)."
       }
     },
     {
@@ -92,7 +92,7 @@ import BaseLayout from '../layouts/BaseLayout.astro'
       "name": "How do I invest in a pool?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Tap the Invest button on any alert — it links directly to the pool on DeFiLlama where you can connect your wallet and deposit. No funds ever pass through YieldRadar. We only provide information."
+        "text": "Tap the Invest button on any alert — it opens the protocol page on DeFiLlama where you can connect your wallet and deposit. No funds ever pass through YieldRadar. We only provide information."
       }
     }
   ]
@@ -133,7 +133,7 @@ import BaseLayout from '../layouts/BaseLayout.astro'
         <span class="stat-label">Pass our quality filters</span>
       </div>
       <div class="stat">
-        <span class="stat-number">6</span>
+        <span class="stat-number">10</span>
         <span class="stat-label">Chains monitored</span>
       </div>
       <div class="stat">
@@ -198,7 +198,7 @@ import BaseLayout from '../layouts/BaseLayout.astro'
         <span class="alt-feature">Risk scoring</span>
         <span>None</span>
         <span>Opinions only</span>
-        <span class="alt-us">6-factor model</span>
+        <span class="alt-us">10-factor model</span>
       </div>
       <div class="alt-row">
         <span class="alt-feature">Security checks</span>
@@ -238,7 +238,7 @@ import BaseLayout from '../layouts/BaseLayout.astro'
   <div class="section-inner">
     <h2>Risk scoring that actually works</h2>
     <p class="lead">
-      High APY means nothing if the protocol rugs next week. We score every pool on six factors, not just yield.
+      High APY means nothing if the protocol rugs next week. We score every pool on ten weighted factors, not just yield.
       <a href="/docs" style="color: var(--color-primary); text-decoration: underline; font-size: 0.9rem;">See the full methodology →</a>
     </p>
     <dl class="tiers">
@@ -292,7 +292,7 @@ import BaseLayout from '../layouts/BaseLayout.astro'
               <span class="tg-value positive">↑ 0.3%</span>
             </div>
           </div>
-          <div class="tg-meta">Ethereum · Lending</div>
+          <div class="tg-meta">Ethereum</div>
           <div class="tg-buttons">
             <span class="tg-btn">📊 Details</span>
             <span class="tg-btn">🔗 Invest</span>
@@ -325,7 +325,7 @@ import BaseLayout from '../layouts/BaseLayout.astro'
               <span class="tg-value positive">↑ 2.5%</span>
             </div>
           </div>
-          <div class="tg-meta">Base · LP / Yield Farming</div>
+          <div class="tg-meta">Base</div>
           <div class="tg-buttons">
             <span class="tg-btn">📊 Details</span>
             <span class="tg-btn">🔗 Invest</span>
@@ -358,7 +358,7 @@ import BaseLayout from '../layouts/BaseLayout.astro'
               <span class="tg-value negative">↑ volatile</span>
             </div>
           </div>
-          <div class="tg-meta">Solana · LP — Low TVL, extreme APY, memecoin pair</div>
+          <div class="tg-meta">Solana</div>
           <div class="tg-buttons">
             <span class="tg-btn">📊 Details</span>
             <span class="tg-btn">🔗 Invest</span>
@@ -400,7 +400,7 @@ import BaseLayout from '../layouts/BaseLayout.astro'
 <section class="chains" id="chains">
   <div class="section-inner">
     <h2>Chain coverage</h2>
-    <p class="lead">Monitoring pools across 6 chains — covering over 75% of all DeFi TVL.</p>
+    <p class="lead">Monitoring pools across 10 chains — covering over 85% of all DeFi TVL.</p>
     <div class="chain-grid">
       <div class="chain-badge"><span class="chain-dot" style="background:#627EEA"></span>Ethereum</div>
       <div class="chain-badge"><span class="chain-dot" style="background:#0052FF"></span>Base</div>
@@ -408,6 +408,10 @@ import BaseLayout from '../layouts/BaseLayout.astro'
       <div class="chain-badge"><span class="chain-dot" style="background:#28A0F0"></span>Arbitrum</div>
       <div class="chain-badge"><span class="chain-dot" style="background:#F0B90B"></span>BSC</div>
       <div class="chain-badge"><span class="chain-dot" style="background:#8247E5"></span>Polygon</div>
+      <div class="chain-badge"><span class="chain-dot" style="background:#FF0420"></span>Optimism</div>
+      <div class="chain-badge"><span class="chain-dot" style="background:#E84142"></span>Avalanche</div>
+      <div class="chain-badge"><span class="chain-dot" style="background:#00D395"></span>Hyperliquid</div>
+      <div class="chain-badge"><span class="chain-dot" style="background:#6FBCF0"></span>Sui</div>
     </div>
   </div>
 </section>
@@ -422,16 +426,16 @@ import BaseLayout from '../layouts/BaseLayout.astro'
         <dd class="stat-label">Yield pools monitored (filtered from 18,632)</dd>
       </div>
       <div class="stat">
-        <dt class="stat-number">6</dt>
-        <dd class="stat-label">Chains covered — Ethereum, Base, Solana, Arbitrum, BSC, Polygon</dd>
+        <dt class="stat-number">10</dt>
+        <dd class="stat-label">Chains covered — Ethereum, Base, Solana, Arbitrum, BSC, Polygon, Optimism, Avalanche, Hyperliquid, Sui</dd>
       </div>
       <div class="stat">
-        <dt class="stat-number">75%+</dt>
+        <dt class="stat-number">85%+</dt>
         <dd class="stat-label">Of all DeFi TVL covered by monitored chains</dd>
       </div>
       <div class="stat">
-        <dt class="stat-number">6</dt>
-        <dd class="stat-label">Risk factors per pool — APY/volatility, TVL, trend, IL, maturity, security</dd>
+        <dt class="stat-number">10</dt>
+        <dd class="stat-label">Risk factors per pool — APY/volatility, TVL, trend, IL, maturity, security (token, address, rugpull), protocol tier, emission decay</dd>
       </div>
       <div class="stat">
         <dt class="stat-number">4</dt>
@@ -443,10 +447,10 @@ import BaseLayout from '../layouts/BaseLayout.astro'
       </div>
       <div class="stat">
         <dt class="stat-number">GoPlus</dt>
-        <dd class="stat-label">Security API integration for token safety checks</dd>
+        <dd class="stat-label">Security API — token, address, rugpull, approval, and phishing checks</dd>
       </div>
       <div class="stat">
-        <dt class="stat-number">504</dt>
+        <dt class="stat-number">740</dt>
         <dd class="stat-label">Test cases in the Vitest suite</dd>
       </div>
     </dl>
@@ -464,7 +468,7 @@ import BaseLayout from '../layouts/BaseLayout.astro'
           <li>10 alerts per day</li>
           <li>Basic chain and risk filters</li>
           <li>Daily digest</li>
-          <li>All 6 chains</li>
+          <li>All 10 chains</li>
         </ul>
         <a href="https://t.me/yieldradar_bot" class="cta-secondary" target="_blank" rel="noopener">Get started →</a>
       </div>
@@ -564,22 +568,28 @@ import BaseLayout from '../layouts/BaseLayout.astro'
         </ul>
       </div>
       <div class="roadmap-column">
-        <h3>🔄 Next up (v1.2 — Q2 2026)</h3>
+        <h3>✅ Shipped (v1.2 — April 2026)</h3>
         <ul>
-          <li>More chains coming soon</li>
+          <li>4 new chains — Optimism, Avalanche, Hyperliquid L1, Sui</li>
           <li>Launch pricing — $9.99/mo (locks in forever)</li>
-          <li>Scoring track record &amp; backtesting dashboard</li>
-          <li>Alert quality improvements based on user feedback</li>
+          <li>Alert deduplication with persistent tracking</li>
+          <li>Minimum APY filter</li>
+          <li>Data export (CSV / JSON)</li>
+          <li>GoPlus expanded — 5 security endpoints (token, address, rugpull, approval, phishing)</li>
+          <li>Emission decay detection</li>
+          <li>Simplified onboarding (5→3 steps)</li>
+          <li>Pipeline fetch hang fix</li>
         </ul>
       </div>
       <div class="roadmap-column">
         <h3>🔮 Planned (v2.0 — H2 2026)</h3>
         <ul>
+          <li>Scoring track record &amp; backtesting dashboard</li>
           <li>Yield collapse prediction (LSTM anomaly detection)</li>
           <li>Social sentiment signals (crypto Twitter / Reddit)</li>
           <li>REST API access (Power tier)</li>
-          <li>Data export (CSV / JSON)</li>
           <li>Protocol exploit tracking (REKT database)</li>
+          <li>Governance token</li>
         </ul>
       </div>
       <div class="roadmap-column">
@@ -613,11 +623,11 @@ import BaseLayout from '../layouts/BaseLayout.astro'
       </details>
       <details class="faq-item">
         <summary>What chains are supported?</summary>
-        <p>We currently monitor pools on Ethereum, Base, Solana, Arbitrum, BSC, and Polygon — covering over 75% of all DeFi TVL. More chains are planned for future updates.</p>
+        <p>We currently monitor pools on 10 chains — Ethereum, Base, Solana, Arbitrum, BSC, Polygon, Optimism, Avalanche, Hyperliquid L1, and Sui — covering over 85% of all DeFi TVL.</p>
       </details>
       <details class="faq-item">
         <summary>How does the risk scoring work?</summary>
-        <p>Every pool is scored 0–100 based on six factors: APY volatility, TVL quality, 7-day trend, impermanent loss risk, pool maturity, and GoPlus token security analysis. Each factor has a specific weight in the composite score. <a href="/docs">See the full methodology →</a></p>
+        <p>Every pool is scored 0–100 based on ten weighted factors: APY volatility, TVL quality, 7-day trend, impermanent loss risk, pool maturity, GoPlus token security, address security, rugpull detection, protocol tier, and emission decay. Each factor has a specific weight in the composite score. <a href="/docs">See the full methodology →</a></p>
       </details>
       <details class="faq-item">
         <summary>How do I pay for Pro?</summary>
@@ -641,11 +651,11 @@ import BaseLayout from '../layouts/BaseLayout.astro'
       </details>
       <details class="faq-item">
         <summary>What are the alert buttons?</summary>
-        <p>Every alert has three inline buttons: <strong>Details</strong> (opens a deep-dive analysis with yield breakdown, risk factors, and similar pools), <strong>Invest</strong> (links directly to the pool on DeFiLlama), and <strong>Mute</strong> (silences alerts for that pool).</p>
+        <p>Every alert has three inline buttons: <strong>Details</strong> (opens a deep-dive analysis with yield breakdown, risk factors, and similar pools), <strong>Invest</strong> (links to the protocol page on DeFiLlama), and <strong>Mute</strong> (silences alerts for that pool).</p>
       </details>
       <details class="faq-item">
         <summary>How do I invest in a pool?</summary>
-        <p>Tap the <strong>Invest</strong> button on any alert — it links directly to the pool on DeFiLlama where you can connect your wallet and deposit. No funds ever pass through YieldRadar. We only provide information.</p>
+        <p>Tap the <strong>Invest</strong> button on any alert — it opens the protocol page on DeFiLlama where you can connect your wallet and deposit. No funds ever pass through YieldRadar. We only provide information.</p>
       </details>
     </div>
   </div>

--- a/src/pages/learn.astro
+++ b/src/pages/learn.astro
@@ -96,7 +96,7 @@ import BaseLayout from '../layouts/BaseLayout.astro'
   <div class="section-inner">
     <h2>How Does DeFi Risk Scoring Work?</h2>
     <p>Risk scoring in DeFi involves analyzing multiple factors and combining them into a single composite score that represents the overall risk of a yield pool. The goal is to replace gut feelings with quantifiable metrics.</p>
-    <p>A typical multi-factor model considers: APY volatility (how stable is the yield), TVL quality (how deep is the liquidity and is it growing or shrinking), 7-day trend (is the pool improving or deteriorating), impermanent loss potential (based on token pair volatility), pool maturity (how long has the pool existed), and token security (are the tokens safe to hold and trade).</p>
+    <p>A comprehensive multi-factor model considers: APY volatility (how stable is the yield), TVL quality (how deep is the liquidity), 7-day trend (improving or deteriorating), impermanent loss potential, pool maturity, token security (GoPlus honeypot and malicious contract detection), address security (sanctions and phishing flags), rugpull detection, protocol tier (audit status and protocol age), and emission decay (detecting unsustainable reward structures).</p>
     <p>Each factor is weighted according to its predictive value. The composite score (usually 0–100) places each pool into a risk tier: safe (75–100), watch (50–74), speculative (25–49), or danger (0–24). This gives investors a quick signal without requiring them to analyze each factor individually.</p>
     <p><a href="/docs" style="color: var(--color-primary); text-decoration: underline;">See YieldRadar's full scoring methodology →</a></p>
   </div>
@@ -151,7 +151,7 @@ import BaseLayout from '../layouts/BaseLayout.astro'
 <section class="section-inner" style="padding: 3rem 0;">
   <div style="background: var(--color-card); border: 1px solid var(--color-border); border-radius: 12px; padding: 2rem; text-align: center;">
     <h2>Monitor these strategies automatically</h2>
-    <p style="margin: 1rem 0;">YieldRadar monitors 3,800+ pools across 6 chains and scores each one on risk — <a href="https://t.me/yieldradar_bot" style="color: var(--color-primary); text-decoration: underline;">start free on Telegram</a>.</p>
+    <p style="margin: 1rem 0;">YieldRadar monitors 3,800+ pools across 10 chains and scores each one on risk — <a href="https://t.me/yieldradar_bot" style="color: var(--color-primary); text-decoration: underline;">start free on Telegram</a>.</p>
     <a href="https://t.me/yieldradar_bot" class="cta-primary" target="_blank" rel="noopener">Open in Telegram →</a>
   </div>
 </section>


### PR DESCRIPTION
Comprehensive documentation update across 5 files (85 insertions, 48 deletions) to reflect the current bot state after v1.2.

Chain count 6 to 10, scoring model 6 to 10 factors, GoPlus 5 endpoints, test count 504 to 740, Invest button accuracy, roadmap and changelog updates, mockup fixes.

Closes #25 #26 #27 #28 #29 #30 #31 #32 #33 #34 #35 #36 #37 #38