### PR TITLE
fix: standardize Hyperliquid L1 naming and pool count

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -410,7 +410,7 @@ import BaseLayout from '../layouts/BaseLayout.astro'
       <div class="chain-badge"><span class="chain-dot" style="background:#8247E5"></span>Polygon</div>
       <div class="chain-badge"><span class="chain-dot" style="background:#FF0420"></span>Optimism</div>
       <div class="chain-badge"><span class="chain-dot" style="background:#E84142"></span>Avalanche</div>
-      <div class="chain-badge"><span class="chain-dot" style="background:#00D395"></span>Hyperliquid</div>
+      <div class="chain-badge"><span class="chain-dot" style="background:#00D395"></span>Hyperliquid L1</div>
       <div class="chain-badge"><span class="chain-dot" style="background:#6FBCF0"></span>Sui</div>
     </div>
   </div>
@@ -427,7 +427,7 @@ import BaseLayout from '../layouts/BaseLayout.astro'
       </div>
       <div class="stat">
         <dt class="stat-number">10</dt>
-        <dd class="stat-label">Chains covered — Ethereum, Base, Solana, Arbitrum, BSC, Polygon, Optimism, Avalanche, Hyperliquid, Sui</dd>
+        <dd class="stat-label">Chains covered — Ethereum, Base, Solana, Arbitrum, BSC, Polygon, Optimism, Avalanche, Hyperliquid L1, Sui</dd>
       </div>
       <div class="stat">
         <dt class="stat-number">85%+</dt>
@@ -529,7 +529,7 @@ import BaseLayout from '../layouts/BaseLayout.astro'
       <div class="trust-item">
         <svg aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
         <h3>Historical data advantage</h3>
-        <p>Months of APY snapshots and trend data across 18K pools. A weekend project starts from zero — we've been collecting since March 2026.</p>
+        <p>Months of APY snapshots and trend data across ~15,000 pools. A weekend project starts from zero — we've been collecting since March 2026.</p>
       </div>
       <div class="trust-item">
         <svg aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/></svg>


### PR DESCRIPTION
3 consistency fixes: Hyperliquid L1 naming in chain badge + by-the-numbers, and 18K→~15000 pool count in moat section