### PR TITLE
fix: update test count from 755 to 757

### DIFF
--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -34,7 +34,7 @@ import BaseLayout from '../layouts/BaseLayout.astro'
         <li>Pipeline fetch hang fix — resolved timeout issues in DeFiLlama data pulls</li>
         <li>API audit fixes across the data pipeline — improved error handling and retry logic</li>
         <li>Alert message formatting improvements with inline action buttons</li>
-        <li>Test suite expanded from 504 to 755 tests</li>
+        <li>Test suite expanded from 504 to 757 tests</li>
       </ul>
     </div>
   </div>
@@ -82,7 +82,7 @@ import BaseLayout from '../layouts/BaseLayout.astro'
         <li>SQLite (better-sqlite3, WAL mode) for persistent storage</li>
         <li>Grammy bot framework with conversations plugin</li>
         <li>Node.js 24 with TypeScript (ESM, strict mode)</li>
-        <li>Vitest test suite (755 tests)</li>
+        <li>Vitest test suite (757 tests)</li>
       </ul>
     </div>
   </div>

--- a/src/pages/docs.astro
+++ b/src/pages/docs.astro
@@ -29,7 +29,7 @@ import BaseLayout from '../layouts/BaseLayout.astro'
     <dt>Database</dt>
     <dd>SQLite (better-sqlite3, WAL mode)</dd>
     <dt>Testing</dt>
-    <dd>Vitest (755 tests)</dd>
+    <dd>Vitest (757 tests)</dd>
     <dt>Deployment</dt>
     <dd>Docker, multi-stage build</dd>
   </dl>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -450,7 +450,7 @@ import BaseLayout from '../layouts/BaseLayout.astro'
         <dd class="stat-label">Security API — token, address, rugpull, approval, and phishing checks</dd>
       </div>
       <div class="stat">
-        <dt class="stat-number">755</dt>
+        <dt class="stat-number">757</dt>
         <dd class="stat-label">Test cases in the Vitest suite</dd>
       </div>
     </dl>


### PR DESCRIPTION
## Sync audit update

Post-merge sync audit for defi-yield-bot PRs #102, #103, #104 caught a stale test count.

**Changes:**
- `index.astro`: 755 → 757 in stats section
- `docs.astro`: 755 → 757 in tech stack
- `changelog.astro`: 755 → 757 in both v1.0 and v1.1 entries

**Verified against:** `npm test` → 757 passing (42 test files)

No other drift found — pool counts (~15K raw, ~2K eligible), chain count (10), scoring formula (log-percentile), risk tiers, and FAQ all match live bot state.