### PR TITLE
feat: add trust signals — powered-by section, enhanced footer, nav scoring link

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -62,6 +62,7 @@ const { title, description = "Real-time DeFi yield intelligence with multi-facto
         </a>
         <div class="nav-links" id="nav-links">
           <a href="/#how">How it works</a>
+          <a href="/#scoring">Scoring</a>
           <a href="/#pricing">Pricing</a>
           <a href="/#faq">FAQ</a>
           <a href="/#roadmap">Roadmap</a>
@@ -93,11 +94,14 @@ const { title, description = "Real-time DeFi yield intelligence with multi-facto
           <span class="footer-tagline">DeFi yield intelligence</span>
         </div>
         <div class="footer-links">
-          <a href="https://t.me/yieldradar_bot" target="_blank" rel="noopener">Telegram</a>
+          <a href="https://t.me/yieldradar_bot" target="_blank" rel="noopener">Telegram Bot</a>
           <a href="https://github.com/goncalovelosa/yield-radar" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://defillama.com" target="_blank" rel="noopener">DeFiLlama</a>
+          <a href="https://gopluslabs.io" target="_blank" rel="noopener">GoPlus</a>
           <a href="/docs">Docs</a>
+          <a href="/changelog">Changelog</a>
         </div>
-        <div class="footer-copy">MIT License · YieldRadar.io</div>
+        <div class="footer-copy">MIT License · YieldRadar.io · Built with DeFiLlama &amp; GoPlus</div>
       </div>
     </footer>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -519,6 +519,27 @@ import BaseLayout from '../layouts/BaseLayout.astro'
   </div>
 </section>
 
+<section class="powered-by" id="powered-by">
+  <div class="section-inner">
+    <h2>Powered by trusted protocols</h2>
+    <p class="lead">YieldRadar doesn't invent data — it aggregates and enriches from the most trusted sources in DeFi.</p>
+    <div class="trust-grid">
+      <div class="trust-item">
+        <svg aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/><path d="M9 12l2 2 4-4"/></svg>
+        <h3>DeFiLlama</h3>
+        <p>The largest DeFi TVL aggregator — $100B+ tracked across 200+ chains. Our primary data source for pool data, APY, TVL, protocol metadata, and audit status. Updated every 5 minutes.</p>
+        <a href="https://defillama.com" target="_blank" rel="noopener" style="color: var(--color-primary); text-decoration: underline; font-size: 0.85rem;">defillama.com →</a>
+      </div>
+      <div class="trust-item">
+        <svg aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/></svg>
+        <h3>GoPlus Security</h3>
+        <p>Industry-standard security API — 5 endpoints integrated: token security, address security, rugpull detection, approval security, and phishing site detection. Every pool gets a weighted security multiplier.</p>
+        <a href="https://gopluslabs.io" target="_blank" rel="noopener" style="color: var(--color-primary); text-decoration: underline; font-size: 0.85rem;">gopluslabs.io →</a>
+      </div>
+    </div>
+  </div>
+</section>
+
 <section class="moat" id="moat">
   <div class="section-inner">
     <h2>Not just another DeFiLlama wrapper</h2>


### PR DESCRIPTION
Issue #1 — Social proof / trust signals

Since YieldRadar is pre-launch, this PR adds honest trust signals instead of fabricated social proof.

Changes:
- New Powered by trusted protocols section (DeFiLlama, GoPlus)
- Enhanced footer with 6 links (was 3)
- Added Scoring to nav links
- Footer copy: Built with DeFiLlama and GoPlus