### PR TITLE
feat: add jargon glossary section + cross-link docs terms to learn page

### DIFF
--- a/src/pages/docs.astro
+++ b/src/pages/docs.astro
@@ -134,10 +134,10 @@ import BaseLayout from '../layouts/BaseLayout.astro'
   <h2>Risk scoring model</h2>
   <p>Each pool receives a composite score based on ten weighted factors. The score is normalized to a 0–100 scale where higher is safer.</p>
 
-  <h3>The formula</h3>
-  <div class="docs-formula">
+      <h3>The formula</h3>
+      <div class="docs-formula">
     <p><code>rawScore = APY / max(sigma, 0.01)</code></p>
-    <p class="formula-note">where <strong>sigma</strong> is the standard deviation of APY over available snapshots — measures yield stability</p>
+    <p class="formula-note">where <strong>APY</strong> is the Annual Percentage Yield (including compounding) and <strong>sigma</strong> is the standard deviation of APY over available snapshots — measures yield stability. <a href="/learn#apy-vs-apr" style="color: var(--color-primary); font-size: 0.85rem;">Learn more about APY →</a></p>
 
     <p><code>riskAdjustedScore = rawScore × TVL_multiplier × trend_multiplier × IL_multiplier × maturity_multiplier</code></p>
     <p class="formula-note">four core multipliers adjust the raw score up or down based on pool-specific risk factors</p>
@@ -192,7 +192,7 @@ import BaseLayout from '../layouts/BaseLayout.astro'
           <td>Yield adjusted for stability — high APY with high volatility scores lower</td>
         </tr>
         <tr>
-          <td>TVL quality</td>
+          <td><a href="/learn#what-is-tvl" style="color: var(--color-primary);">TVL</a> quality</td>
           <td>Multiplier</td>
           <td>DeFiLlama</td>
           <td>Deeper liquidity = more scrutiny, harder to manipulate</td>
@@ -204,7 +204,7 @@ import BaseLayout from '../layouts/BaseLayout.astro'
           <td>Rising or stable APY is positive; sharp drops are penalized</td>
         </tr>
         <tr>
-          <td>Impermanent loss</td>
+          <td><a href="/learn#impermanent-loss" style="color: var(--color-primary);">Impermanent loss</a></td>
           <td>0.5x penalty</td>
           <td>DeFiLlama</td>
           <td>LP pairs with volatile tokens face IL risk</td>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -682,4 +682,37 @@ import BaseLayout from '../layouts/BaseLayout.astro'
   </div>
 </section>
 
+<section class="glossary" id="glossary" style="padding: 2.5rem 0;">
+  <div class="section-inner">
+    <h2>Key terms</h2>
+    <p class="lead">New to DeFi? Here's what the jargon means. <a href="/learn" style="color: var(--color-primary); text-decoration: underline;">Read the full guide →</a></p>
+    <dl class="glossary-grid">
+      <div>
+        <dt>APY</dt>
+        <dd>Annual Percentage Yield — the yearly return on your deposit, including compounding. Higher APY means more earnings, but often means higher risk.</dd>
+      </div>
+      <div>
+        <dt>TVL</dt>
+        <dd>Total Value Locked — how much money is deposited in a pool or protocol. Higher TVL generally means more trust and deeper liquidity.</dd>
+      </div>
+      <div>
+        <dt>Impermanent Loss (IL)</dt>
+        <dd>The hidden cost of providing liquidity to trading pairs. When token prices diverge, your holdings are worth less than if you'd just held the tokens. Only affects LP (liquidity provider) pools.</dd>
+      </div>
+      <div>
+        <dt>Risk Score</dt>
+        <dd>YieldRadar's 0–100 rating for each pool. 75–100 is Safe, 50–74 is Watch, 25–49 is Speculative, 0–24 is Danger. Based on 10 weighted factors.</dd>
+      </div>
+      <div>
+        <dt>GoPlus</dt>
+        <dd>A security API that scans tokens for honeypots, malicious contracts, and high transfer taxes. YieldRadar integrates 5 GoPlus endpoints into the risk score.</dd>
+      </div>
+      <div>
+        <dt>Emission Decay</dt>
+        <dd>When a protocol's reward tokens run out, the APY drops. YieldRadar detects this pattern and penalizes pools with unsustainable reward structures.</dd>
+      </div>
+    </dl>
+  </div>
+</section>
+
 </BaseLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -260,6 +260,27 @@ img {
   margin-top: 2.5rem;
 }
 
+/* Glossary */
+.glossary-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.5rem;
+  margin-top: 1.5rem;
+}
+.glossary-grid dt {
+  font-family: var(--font-heading);
+  font-weight: 700;
+  font-size: 1.1rem;
+  color: var(--color-text);
+  margin-bottom: 0.4rem;
+}
+.glossary-grid dd {
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+  line-height: 1.6;
+  margin: 0;
+}
+
 .stat {
   background: var(--color-surface);
   border: 1px solid var(--color-border);
@@ -768,6 +789,7 @@ img {
 
   /* Stats grid 2-col on mobile */
   .stats-grid { grid-template-columns: repeat(2, 1fr); }
+  .glossary-grid { grid-template-columns: repeat(2, 1fr); }
 
   /* Comparison table horizontal scroll */
   .alt-grid { overflow-x: auto; -webkit-overflow-scrolling: touch; }


### PR DESCRIPTION
Issue #17

Adds a Key terms glossary section at the bottom of the landing page with 6 terms: APY, TVL, Impermanent Loss, Risk Score, GoPlus, Emission Decay. Each links to the full Learn page guide.

Also cross-links TVL and Impermanent Loss in docs.astro factor table to their learn page anchors.