### PR TITLE
fix: expand comparison table with data freshness and multi-chain rows

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -207,6 +207,18 @@ import BaseLayout from '../layouts/BaseLayout.astro'
         <span class="alt-us">GoPlus automated</span>
       </div>
       <div class="alt-row">
+        <span class="alt-feature">Data freshness</span>
+        <span>Manual refresh</span>
+        <span>Whenever posted</span>
+        <span class="alt-us">Every 5 minutes</span>
+      </div>
+      <div class="alt-row">
+        <span class="alt-feature">Multi-chain coverage</span>
+        <span>Yes (manual)</span>
+        <span>Usually 1–2 chains</span>
+        <span class="alt-us">10 chains auto-scanned</span>
+      </div>
+      <div class="alt-row">
         <span class="alt-feature">Personalized filters</span>
         <span>Basic</span>
         <span>No</span>


### PR DESCRIPTION
Issue #20

Comparison table already existed with 6 rows. Added 2 more impactful differentiators:
- Data freshness (manual vs whenever vs every 5 min)
- Multi-chain coverage (manual vs usually 1-2 vs 10 auto-scanned)